### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -210,6 +210,8 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [test, build]
     if: github.event_name == 'release' && github.event.action == 'published'
 


### PR DESCRIPTION
Potential fix for [https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/6](https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/6)

To fix the problem, add a `permissions` block to the `publish` job in `.github/workflows/ci-cd.yml` that restricts the `GITHUB_TOKEN` to the minimum required permissions. Since the job only downloads artifacts and publishes to PyPI (using a secret, not the `GITHUB_TOKEN`), it only needs `contents: read` permission. This change should be made by inserting the following block under the `publish` job definition (after line 212, before `needs` or `steps`):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
