### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -178,6 +178,8 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [test, security]
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/5](https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block to the `build` job in `.github/workflows/ci-cd.yml`. The minimal required permission for this job is `contents: read`, which allows the job to read repository contents but not write to them. This change should be made directly under the `build:` job definition, before the `needs:` or `steps:` keys. No additional imports or definitions are required, as this is a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
