### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -115,6 +115,8 @@ jobs:
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/4](https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/4)

To fix the problem, add a `permissions` block to the `docs` job in `.github/workflows/ci-cd.yml` that restricts the GITHUB_TOKEN to the minimum required. Since the `docs` job only needs to read repository contents (for checkout and artifact upload), set `contents: read`. This change should be made directly under the `docs:` job definition, at the same indentation level as `runs-on` and `steps`. No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
