### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,6 +83,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/3](https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/3)

To fix the problem, add a `permissions` block to the `security` job in `.github/workflows/ci-cd.yml` that restricts the `GITHUB_TOKEN` to the minimum required privileges. Since the job only runs static analysis and does not need to write to the repository or interact with GitHub APIs, the minimal permission is `contents: read`. This change should be made by inserting the following lines under the `runs-on` key in the `security` job (after line 85):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
