### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/2](https://github.com/GraysonBellamy/pynetzsch/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `performance` job in `.github/workflows/ci-cd.yml` that restricts the GITHUB_TOKEN to the minimum required. Since the job only needs to check out code and does not need to write to the repository or perform privileged actions, the minimal permission required is `contents: read`. This change should be made by adding the following lines under the `performance:` job definition, at the same indentation level as `runs-on`, `needs`, and `if`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
