### PR TITLE
Enhance CI/CD performance workflow with artifacts and better uv setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,14 +74,26 @@ jobs:
       with:
         python-version: "3.11"
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v2
+      with:
+        version: "latest"
+
     - name: Install dependencies
       run: |
-        pip install uv
         uv sync --extra performance
 
     - name: Run performance benchmarks
       run: |
-        uv run python scripts/benchmarks.py --runs 3
+        uv run python scripts/benchmarks.py --runs 3 > performance-results.txt 2>&1
+        echo "Performance benchmark completed"
+        cat performance-results.txt
+
+    - name: Upload performance results
+      uses: actions/upload-artifact@v4
+      with:
+        name: performance-results
+        path: performance-results.txt
 
   security:
     name: Security Scan


### PR DESCRIPTION
- Add uv installation step using astral-sh/setup-uv@v2 for consistency
- Capture performance benchmark results to file for artifact upload
- Upload performance results as GitHub Actions artifacts
- Improve output visibility by displaying results in workflow logs
- Maintain backward compatibility with existing benchmark script

These improvements provide:
- Better performance tracking across PRs
- Artifact retention for performance analysis
- Consistent uv setup across all workflow jobs
- Enhanced debugging capabilities for performance issues