### PR TITLE
ci: publish docs to Cloudflare Pages at pyngb.graysonbellamy.dev

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -170,8 +170,6 @@ jobs:
     - name: Build documentation
       run: |
         uv run zensical build
-        # Add .nojekyll file for GitHub Pages
-        touch site/.nojekyll
 
     - name: Upload documentation artifacts
       uses: actions/upload-artifact@v5
@@ -187,12 +185,6 @@ jobs:
 
     permissions:
       contents: read
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
     - name: Download documentation artifacts
@@ -201,17 +193,12 @@ jobs:
         name: documentation
         path: ./site
 
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-
-    - name: Upload to GitHub Pages
-      uses: actions/upload-pages-artifact@v3
+    - name: Deploy to Cloudflare Pages
+      uses: cloudflare/wrangler-action@v3
       with:
-        path: ./site
-
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: pages deploy site --project-name=pyngb-docs --branch=main
 
   build:
     name: Build Package

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ version: 0.2.0
 date-released: 2026-07-03
 license: MIT
 repository-code: "https://github.com/GraysonBellamy/pyngb"
-url: "https://graysonbellamy.github.io/pyngb/"
+url: "https://pyngb.graysonbellamy.dev/"
 keywords:
   - ngb
   - netzsch

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://graysonbellamy.github.io/pyngb/sitemap.xml
+Sitemap: https://pyngb.graysonbellamy.dev/sitemap.xml

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,6 +108,6 @@ import pyngb
 
 ## Getting Help
 
-- **Documentation**: [Full documentation](https://graysonbellamy.github.io/pyngb/)
+- **Documentation**: [Full documentation](https://pyngb.graysonbellamy.dev/)
 - **Issues**: [Report problems](https://github.com/GraysonBellamy/pyngb/issues)
 - **Discussions**: [Ask questions](https://github.com/GraysonBellamy/pyngb/discussions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/GraysonBellamy/pyngb"
-Documentation = "https://graysonbellamy.github.io/pyngb/"
+Documentation = "https://pyngb.graysonbellamy.dev/"
 Repository = "https://github.com/GraysonBellamy/pyngb.git"
 Issues = "https://github.com/GraysonBellamy/pyngb/issues"
 Changelog = "https://github.com/GraysonBellamy/pyngb/blob/main/CHANGELOG.md"

--- a/zensical.toml
+++ b/zensical.toml
@@ -2,7 +2,7 @@
 site_name = "pyngb - NETZSCH STA File Parser"
 site_description = "Comprehensive Python library for parsing and analyzing NETZSCH STA NGB files"
 site_author = "Grayson Bellamy"
-site_url = "https://graysonbellamy.github.io/pyngb/"
+site_url = "https://pyngb.graysonbellamy.dev/"
 
 repo_name = "GraysonBellamy/pyngb"
 repo_url = "https://github.com/GraysonBellamy/pyngb"


### PR DESCRIPTION
## What this does

Cuts the documentation site over from GitHub Pages to **Cloudflare Pages**, served at the custom domain **https://pyngb.graysonbellamy.dev/**.

Docs are still built in CI with the locked `uv` environment (the `docs` build job is unchanged) — only the **deploy** step changes: the built `site/` is uploaded to the `pyngb-docs` Cloudflare Pages project via `wrangler`.

### Changes
- `zensical.toml`: `site_url` → the custom domain (recomputes the base path from `/pyngb/` to root; refreshes the generated sitemap + canonical URLs)
- `.github/workflows/ci-cd.yml`: replace the GitHub Pages deploy job with `cloudflare/wrangler-action@v3`; drop the GitHub Pages-only `.nojekyll` step and the `pages` / `id-token` permissions
- `robots.txt`, `pyproject.toml`, `CITATION.cff`, `examples/README.md`: documentation URL → new domain

### Requires (set up out-of-band, already done)
- Cloudflare Pages project **`pyngb-docs`** (direct upload, production branch `main`)
- Repo secrets **`CLOUDFLARE_API_TOKEN`** (scoped: Account · Cloudflare Pages · Edit) and **`CLOUDFLARE_ACCOUNT_ID`**
- Custom domain `pyngb.graysonbellamy.dev` attached to the Pages project

### ⚠️ Merge ordering
Merge only once the Cloudflare zone is **active** and the custom domain shows **Active** in the Pages project. Merging early would deploy the root-base-path build before the domain resolves.

### After merge
- Confirm the site is live at https://pyngb.graysonbellamy.dev/
- Disable the old GitHub Pages (repo Settings → Pages → Source: None) so it stops serving a stale duplicate
