### PR TITLE
docs: add security response headers (Cloudflare Pages _headers)

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,0 +1,6 @@
+# Security headers applied to every route, served by Cloudflare Pages.
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()


### PR DESCRIPTION
## What

Adds `docs/_headers`, which Cloudflare Pages applies to every route:

- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: geolocation=(), microphone=(), camera=()`

Verified locally that `zensical build` copies the file into `site/_headers`, so it ships with the deploy. This is something GitHub Pages could not do.

## Deliberately not included

A `Content-Security-Policy` — the docs load a few third-party assets (icons8 logo/favicon, analytics, mermaid), so a strict CSP needs per-source testing to avoid breaking them. Worth a follow-up once the sources are enumerated.
