### PR TITLE
docs: drop Google Analytics in favor of Cloudflare Web Analytics

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -78,10 +78,6 @@ toggle.name = "Switch to light mode"
 [project.extra]
 generator = false
 
-[project.extra.analytics]
-provider = "google"
-property = "G-WLVK2ZW663"
-
 [project.extra.analytics.feedback]
 title = "Was this page helpful?"
 


### PR DESCRIPTION
Remove the GA4 provider/property from zensical.toml. Analytics now comes from Cloudflare Web Analytics (cookieless, auto-injected on the proxied domain), so no in-page tag is needed. The 'Was this page helpful?' widget still renders, but its ratings previously fed GA and are no longer recorded (Cloudflare Web Analytics has no custom-event API).